### PR TITLE
feat: Add UI panels and build selection context

### DIFF
--- a/src/components/UI/InfoPanel/InfoPanel.module.css
+++ b/src/components/UI/InfoPanel/InfoPanel.module.css
@@ -1,0 +1,60 @@
+.infoPanel {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  min-width: 160px;
+  width: auto;
+
+  display: flex;
+  flex-direction: column;
+
+  background: #e0bf9b;
+  color: #2e2c2c;
+
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 2px solid rgba(46, 44, 44, 0.12);
+}
+
+.infoPanel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.infoPanel__body {
+  margin-top: 8px;
+}
+
+.infoPanel__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 4px;
+}
+
+.infoPanel__rowName {
+  font-size: 13px;
+  color: #3b3b3b;
+}
+
+.infoPanel__rowData {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.infoPanel__divider {
+  height: 1px;
+  width: 100%;
+  background: rgba(46, 44, 44, 0.12);
+  margin: 6px 0;
+}
+
+.infoPanel__title {
+  font-weight: 700;
+}
+
+.infoPanel__chev {
+  opacity: 0.9;
+}

--- a/src/components/UI/InfoPanel/InfoPanel.tsx
+++ b/src/components/UI/InfoPanel/InfoPanel.tsx
@@ -1,0 +1,27 @@
+import styles from "./InfoPanel.module.css";
+
+function Row({ name, data }: { name: string; data: string }) {
+  return (
+    <div className={styles.infoPanel__row}>
+      <div className={styles.infoPanel__rowName}>{name}</div>
+      <div className={styles.infoPanel__rowData}>{data}</div>
+    </div>
+  );
+}
+
+export default function InfoPanel() {
+  return (
+    <div className={styles.infoPanel}>
+      <div className={styles.infoPanel__header}>
+        <div className={styles.infoPanel__title}>Весёлая ферма</div>
+        <div className={styles.infoPanel__chev}>&gt;</div>
+      </div>
+      <div className={styles.infoPanel__body}>
+        <div className={styles.infoPanel__divider}></div>
+        <Row name={"Баланс"} data={"1000"} />
+        <Row name={"Жители"} data={"3"} />
+        <Row name={"Уровень"} data={"1"} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/UI/LeftPanel/LeftPanel.module.css
+++ b/src/components/UI/LeftPanel/LeftPanel.module.css
@@ -1,0 +1,67 @@
+.leftPanel {
+  position: absolute;
+  top: 15px;
+  left: 15px;
+
+  background: #e2c0a0;
+  color: #2e2c2c;
+
+  width: 220px;
+
+  display: flex;
+  flex-direction: column;
+
+  border-radius: 6px;
+  border: 2px solid rgba(46, 44, 44, 0.12);
+}
+
+.leftPanel__body {
+  padding: 12px;
+}
+
+.leftPanelSelect {
+  background: transparent;
+  border: none;
+  outline: none;
+
+  margin: 12px;
+
+  font-size: 16px;
+  font-weight: 700;
+  color: #2e2c2c;
+}
+
+.buildingsList {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.buildingItem {
+  display: flex;
+  flex-direction: column;
+
+  border-radius: 2px;
+  padding: 8px 10px;
+  background: #fbf0e5;
+  border: 1px solid rgba(46, 44, 44, 0.08);
+}
+
+.buildingItem:hover {
+  background: #f6e6d0;
+}
+
+.buildingItem__selected {
+  border: 2px solid rgba(78, 48, 23, 0.9);
+}
+
+.buildingItem__title {
+  font-weight: 700;
+  color: #3b2b20;
+}
+
+.buildingItem__desc {
+  font-size: 12px;
+  color: #5a4634;
+  margin-top: 6px;
+}

--- a/src/components/UI/LeftPanel/LeftPanel.tsx
+++ b/src/components/UI/LeftPanel/LeftPanel.tsx
@@ -1,0 +1,74 @@
+import styles from "./LeftPanel.module.css";
+import { useState } from "react";
+import { BuildingType } from "../../../engine/Types";
+import { BUILDING_CONFIG } from "../../../engine/Constants";
+import { useBuildSelection } from "../../../contexts/BuildSelectionContext";
+
+export default function LeftPanel() {
+  const [picker, setPicker] = useState("buildings");
+
+  return (
+    <div className={styles.leftPanel}>
+      <select
+        className={styles.leftPanelSelect}
+        name="leftPanelSelect"
+        id="leftPanelSelect"
+        value={picker}
+        onChange={(e) => setPicker(e.target.value)}
+      >
+        <option value="buildings">Строения</option>
+        <option value="statistic">Статистика</option>
+        <option value="vilagers">Жители</option>
+        <option value="taxes">Налоги</option>
+      </select>
+      {picker === "buildings" ? <BuildingsPanel /> : null}
+    </div>
+  );
+}
+
+function BuildingsPanel() {
+  const { selected, setSelected } = useBuildSelection();
+
+  const BUILDING_NAMES: Record<BuildingType, string> = {
+    [BuildingType.Main]: "Главное здание",
+    [BuildingType.House]: "Дом",
+    [BuildingType.Granary]: "Амбар",
+    [BuildingType.Greenhouse]: "Теплица",
+    [BuildingType.Market]: "Рынок",
+    [BuildingType.Well]: "Колодец",
+    [BuildingType.Bridge]: "Мост",
+    [BuildingType.Road]: "Дорога",
+    [BuildingType.Garden]: "Огород",
+    [BuildingType.Graveyard]: "Кладбище",
+  };
+
+  const buildingTypes = Object.values(BuildingType) as BuildingType[];
+
+  return (
+    <div className={styles.leftPanel__body}>
+      <div className={styles.buildingsList}>
+        {buildingTypes.map((bt) => {
+          const cfg = (BUILDING_CONFIG as any)[bt];
+          const desc = cfg ? `${cfg.width}x${cfg.length} клетки` : "-";
+          const isSelected = selected === bt;
+          return (
+            <div
+              key={bt}
+              className={
+                isSelected
+                  ? `${styles.buildingItem} ${styles.buildingItem__selected}`
+                  : styles.buildingItem
+              }
+              onClick={() => setSelected(isSelected ? null : bt)}
+            >
+              <div className={styles.buildingItem__title}>
+                {BUILDING_NAMES[bt]}
+              </div>
+              <div className={styles.buildingItem__desc}>{desc}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/MapCanvas.tsx
+++ b/src/components/game/MapCanvas.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { TileType, WorldMap } from "../../engine/WorldMap.ts";
+import { useBuildSelection } from "../../contexts/BuildSelectionContext";
+import { BUILDING_CONFIG } from "../../engine/Constants";
 
 const PALETTE = {
   [TileType.Grass]: "#9EEAA1",
@@ -71,6 +73,12 @@ export default function MapCanvas({
     }
   };
 
+  const { selected } = useBuildSelection();
+  const buildSelectionRef = useRef<{ selected: any } | null>(null);
+  useEffect(() => {
+    buildSelectionRef.current = { selected };
+  }, [selected]);
+
   const drawOverlay = () => {
     const overlay = overlayCanvasRef.current;
     if (!overlay) return;
@@ -84,12 +92,35 @@ export default function MapCanvas({
 
     ctx.strokeStyle = "#acacac";
     ctx.lineWidth = 2;
-    ctx.strokeRect(
-      hovered.col * TILE_SIZE + 1,
-      hovered.row * TILE_SIZE + 1,
-      TILE_SIZE - 2,
-      TILE_SIZE - 2,
-    );
+
+    const { selected } = buildSelectionRef.current ?? { selected: null };
+    if (selected) {
+      const cfg = (BUILDING_CONFIG as any)[selected];
+      const w = cfg?.width ?? 1;
+      const h = cfg?.length ?? 1;
+      ctx.strokeStyle = "rgba(46, 44, 44, 1)";
+      ctx.lineWidth = 3;
+      ctx.fillStyle = "rgba(78,48,23,0.12)";
+      ctx.fillRect(
+        hovered.col * TILE_SIZE + 1,
+        hovered.row * TILE_SIZE + 1,
+        w * TILE_SIZE - 2,
+        h * TILE_SIZE - 2,
+      );
+      ctx.strokeRect(
+        hovered.col * TILE_SIZE + 1,
+        hovered.row * TILE_SIZE + 1,
+        w * TILE_SIZE - 2,
+        h * TILE_SIZE - 2,
+      );
+    } else {
+      ctx.strokeRect(
+        hovered.col * TILE_SIZE + 1,
+        hovered.row * TILE_SIZE + 1,
+        TILE_SIZE - 2,
+        TILE_SIZE - 2,
+      );
+    }
   };
 
   useEffect(() => {
@@ -184,7 +215,8 @@ export default function MapCanvas({
     const row = Math.floor(worldY / TILE_SIZE);
 
     if (col >= 0 && col < MAP_DIMENSION && row >= 0 && row < MAP_DIMENSION) {
-      alert(`x=${col}, y=${row}`);
+      const sel = buildSelectionRef.current?.selected ?? null;
+      alert(`x=${col}, y=${row}` + (sel ? `, selected=${sel}` : ""));
     }
   };
 

--- a/src/contexts/BuildSelectionContext.tsx
+++ b/src/contexts/BuildSelectionContext.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+import type { BuildingType } from "../engine/Types";
+
+type SelectionContextType = {
+  selected: BuildingType | null;
+  setSelected: (b: BuildingType | null) => void;
+};
+
+const SelectionContext = createContext<SelectionContextType | null>(null);
+
+export function BuildSelectionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [selected, setSelected] = useState<BuildingType | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSelected(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <SelectionContext.Provider value={{ selected, setSelected }}>
+      {children}
+    </SelectionContext.Provider>
+  );
+}
+
+export function useBuildSelection() {
+  const ctx = useContext(SelectionContext);
+  if (!ctx) {
+    // Fallback to a noop selection when used outside provider (e.g. background MapCanvas)
+    return {
+      selected: null,
+      setSelected: () => {},
+    };
+  }
+  return ctx;
+}
+
+export default BuildSelectionProvider;

--- a/src/contexts/BuildSelectionContext.tsx
+++ b/src/contexts/BuildSelectionContext.tsx
@@ -33,7 +33,6 @@ export function BuildSelectionProvider({
 export function useBuildSelection() {
   const ctx = useContext(SelectionContext);
   if (!ctx) {
-    // Fallback to a noop selection when used outside provider (e.g. background MapCanvas)
     return {
       selected: null,
       setSelected: () => {},

--- a/src/views/GameView.tsx
+++ b/src/views/GameView.tsx
@@ -1,16 +1,23 @@
 import MapCanvas from "../components/game/MapCanvas.tsx";
+import InfoPanel from "../components/UI/InfoPanel/InfoPanel.tsx";
+import LeftPanel from "../components/UI/LeftPanel/LeftPanel.tsx";
+import { BuildSelectionProvider } from "../contexts/BuildSelectionContext";
 
 export default function GameView() {
   return (
-    <div
-      style={{
-        position: "relative",
-        width: "100vw",
-        height: "100vh",
-        overflow: "hidden",
-      }}
-    >
-      <MapCanvas />
-    </div>
+    <BuildSelectionProvider>
+      <div
+        style={{
+          position: "relative",
+          width: "100vw",
+          height: "100vh",
+          overflow: "hidden",
+        }}
+      >
+        <MapCanvas />
+        <InfoPanel />
+        <LeftPanel />
+      </div>
+    </BuildSelectionProvider>
   );
 }


### PR DESCRIPTION
Introduce InfoPanel and LeftPanel UI components with accompanying CSS modules (warm brown palette, layout and hover/selected styles). Add BuildSelectionContext (provider + useBuildSelection hook) to track selected building with Escape key to clear and a safe fallback when used outside the provider. Update MapCanvas to consume the selection (via a ref to avoid stale closures), draw multi-tile placement overlay based on BUILDING_CONFIG, and include selection info in tile click alerts. Wrap GameView with BuildSelectionProvider and render MapCanvas, InfoPanel and LeftPanel.